### PR TITLE
tweaked to work with JSCompiler and improved test error reporting

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+java -jar tools/compiler.jar --language_in=ECMASCRIPT6 --warning_level=VERBOSE --jscomp_error="*" --compilation_level=ADVANCED --js RegExp.make.js --externs externs.js

--- a/externs.js
+++ b/externs.js
@@ -1,0 +1,4 @@
+/** @type{string} @const */
+RegExp.prototype.flags;
+
+RegExp.make;

--- a/test.html
+++ b/test.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <meta charset="UTF-8">
+<title>RegExp.make Tests</title>
 <style>
   td { font-family: monospace; white-space: pre }
   tr { vertical-align: top }


### PR DESCRIPTION
Running things through closure compiler sussed out a few problems: not checking that match array was not null, passing arguments in wrong order, and typos in method names.  Those fixes are already in, but since I did the  work to annotate I thought I'd see what you think.

Closure compiler's ES6 support is experimental, so some things like consts require over-annotation and pattern decomposition on const doesn't associate annotations with individual symbols.
