### PR TITLE
concat to flags

### DIFF
--- a/RegExp.make.js
+++ b/RegExp.make.js
@@ -971,11 +971,12 @@ RegExp.make = (function () {
   }
 
   function make(flags, template, ...values) {
+    // make is always bound to a flags string
     if ('string' === typeof template && values.length === 0) {
       // Allow RegExp.make(i)`...` to specify flags.
       // This calling convention is disjoint with use as a template tag
       // since the typeof a template record is 'object'.
-      return make.bind(null, template /* use as flags instead */);
+      return make.bind(null, flags + template /* use as flags instead */);
     }
 
     /** @type {!Array.<string>} */


### PR DESCRIPTION
If we can do `myMake = RegExp.make("")("g")("i")("")…` anyway, let it be useful at least :-)

I wonder what TC39 will say to this pattern, though. There are no curried functions in ES6 yet, and no variadic ones for sure.
