### PR TITLE
create a basic .travis.yml file to run presubmit checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "stable"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "regexp-make-js",
+  "version": "1.0.0",
+  "description": "An ES6 string template tag for dynamically creating regular expressions.",
+  "main": "RegExp.make.js",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "node test/all.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mikesamuel/regexp-make-js.git"
+  },
+  "author": "Various",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/mikesamuel/regexp-make-js/issues"
+  },
+  "homepage": "https://github.com/mikesamuel/regexp-make-js#readme",
+  "dependencies": {
+    "babel": "^5.8.29"
+  }
+}

--- a/test/all.js
+++ b/test/all.js
@@ -1,0 +1,3 @@
+require('babel/register');
+require('../RegExp.make.js');
+require('./tests.js');

--- a/test/index.html
+++ b/test/index.html
@@ -24,6 +24,6 @@
     }
   }());</script>
 
-  <script src="RegExp.make.js"></script>
+  <script src="../RegExp.make.js"></script>
   <script src="tests.js"></script>
 </html>


### PR DESCRIPTION
The travis.yml file just runs `npm test` currently, so this change rework tests to run under node using babel to do ES6->ES5 transpilation.

The tests still run in Firefox and via npm test.

TODO: tweak `npm test` to run Closure Compiler as via check.sh
